### PR TITLE
Bug fix, changing JSONObject.getString() to optString() to avoid program crashing

### DIFF
--- a/wookie-services/wookie-redis/src/main/java/org/apache/wookie/services/redis/RedisPreferencesService.java
+++ b/wookie-services/wookie-redis/src/main/java/org/apache/wookie/services/redis/RedisPreferencesService.java
@@ -251,7 +251,7 @@ public class RedisPreferencesService implements PreferencesService {
 	private IPreference rehydrate(String input){
 		if (input == null) return null;
 		JSONObject json = new JSONObject(input);
-		DefaultPreferenceImpl pref = new DefaultPreferenceImpl(json.getString("name"), json.getString("value"), json.getBoolean("readOnly"));
+		DefaultPreferenceImpl pref = new DefaultPreferenceImpl(json.optString("name"), json.optString("value"), json.getBoolean("readOnly"));
 		return pref;
 	}
 	

--- a/wookie-services/wookie-redis/src/main/java/org/apache/wookie/services/redis/RedisSharedContextService.java
+++ b/wookie-services/wookie-redis/src/main/java/org/apache/wookie/services/redis/RedisSharedContextService.java
@@ -519,8 +519,8 @@ public class RedisSharedContextService implements SharedContextService {
 		if (input == null) return null;
 		DefaultSharedDataImpl data;
 		JSONObject json = new JSONObject(input);
-		String value = json.getString("value");
-		String name = json.getString("name");
+		String value = json.optString("value");
+		String name = json.optString("name");
 		data = new DefaultSharedDataImpl(name,value);
 		return data;
 	}
@@ -528,7 +528,7 @@ public class RedisSharedContextService implements SharedContextService {
 	private IParticipant rehydrateParticipant(String input){
 		if (input == null) return null;
 		JSONObject json = new JSONObject(input);
-		String id = json.getString("id");
+		String id = json.optString("id");
 		String name = json.has("name") ? json.getString("name"): null;
 		String thumbnail = json.has("thumbnail") ? json.getString("thumbnail"): null;
 		String role =  json.has("role") ? json.getString("role") : null;


### PR DESCRIPTION
JSONObject.getString() may throw JSONException causing the program crashes, the optString() method is an alternative replacement that has the same function as getString() but is free from crashing